### PR TITLE
Agent pathing avoids watched/noticed tiles without increasing AP cost

### DIFF
--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -8,6 +8,7 @@ local function init( modApi )
     modApi:addGenerationOption("precise_icons", STRINGS.MOD_UI_TWEAKS.OPTIONS.PRECISE_ICONS, STRINGS.MOD_UI_TWEAKS.OPTIONS.PRECISE_ICONS_TIP)
     modApi:addGenerationOption("door_while_dragging", STRINGS.MOD_UI_TWEAKS.OPTIONS.DOORS_WHILE_DRAGGING, STRINGS.MOD_UI_TWEAKS.OPTIONS.DOORS_WHILE_DRAGGING_TIP)
     modApi:addGenerationOption("colored_tracks", STRINGS.MOD_UI_TWEAKS.OPTIONS.COLORED_TRACKS, STRINGS.MOD_UI_TWEAKS.OPTIONS.COLORED_TRACKS_TIP)
+    modApi:addGenerationOption("step_carefully", STRINGS.MOD_UI_TWEAKS.OPTIONS.STEP_CAREFULLY, STRINGS.MOD_UI_TWEAKS.OPTIONS.STEP_CAREFULLY_TIP)
 
     local dataPath = modApi:getDataPath()
     KLEIResourceMgr.MountPackage( dataPath .. "/gui.kwad", "data" )
@@ -29,12 +30,14 @@ local function load( modApi, options )
     local precise_icons = include( modApi:getScriptPath() .. "/precise_icons" )
     local doors_while_dragging = include( modApi:getScriptPath() .. "/doors_while_dragging" )
     local tracks = include( modApi:getScriptPath() .. "/tracks" )
+    local step_carefully = include( modApi:getScriptPath() .. "/step_carefully" )
 
 
     autoEnable(options, "inv_drag_drop")
     autoEnable(options, "precise_icons")
     autoEnable(options, "doors_while_dragging")
     autoEnable(options, "colored_tracks")
+    autoEnable(options, "step_carefully")
 
     i_need_a_dollar( options["need_a_dollar"].enabled )
     precise_icons( options["precise_icons"].enabled )
@@ -42,6 +45,7 @@ local function load( modApi, options )
     doors_while_dragging( options["doors_while_dragging"].enabled )
     precise_ap( options["precise_ap"].enabled )
     tracks( options["colored_tracks"].enabled )
+    step_carefully( options["step_carefully"].enabled )
 end
 
 function _reload_tweaks()

--- a/scripts/step_carefully.lua
+++ b/scripts/step_carefully.lua
@@ -1,0 +1,31 @@
+
+local simdefs = include( "sim/simdefs" )
+local astar_handlers = include( "sim/astar_handlers" )
+
+local function handleNode( originalFunction, self, to_cell, from_node, goal_cell, ... )
+	local n = originalFunction( self, to_cell, from_node, goal_cell, ... )
+
+	if n and self._unit:isPC() then
+		local simquery = self._sim:getQuery()
+		local watchState = simquery.isCellWatched( self._sim, self._unit:getPlayerOwner(), to_cell.x, to_cell.y )
+
+		-- Penalize paths for moving through watched and noticed tiles.
+		-- Penalty is less than difference between paths with different real mp costs for reasonable path lengths.
+		if watchState == simdefs.CELL_WATCHED then
+			n.mCost = n.mCost + 0.001
+			n.score = n.score + 0.001
+		elseif watchState == simdefs.CELL_NOTICED then
+			n.mCost = n.mCost + 0.00001
+			n.score = n.score + 0.00001
+		end
+	end
+
+	return n
+end
+
+
+local patches = {
+    { package = astar_handlers.handler, name = '_handleNode',   f = handleNode },
+}
+
+return monkeyPatch(patches)

--- a/scripts/step_carefully.lua
+++ b/scripts/step_carefully.lua
@@ -49,8 +49,13 @@ local function handleNode( originalFunction, self, to_cell, from_node, goal_cell
 	if n then
 		local simquery = self._sim:getQuery()
 
-		-- Update real MP cost
-		local dc = simquery.getMoveCost( from_node.location, to_cell )
+		-- Update real MP cost. If Neptune is installed, use the alternate move cost function.
+		local dc
+		if simquery.getTrueMoveCost then
+			dc = simquery.getTrueMoveCost( self._unit, from_node.location, to_cell )
+		else
+			dc = simquery.getMoveCost( from_node.location, to_cell )
+		end
 		n.realCost = from_node.realCost + dc
 
 		-- Check max MP against the real MP cost.

--- a/scripts/step_carefully.lua
+++ b/scripts/step_carefully.lua
@@ -1,16 +1,66 @@
 
-local simdefs = include( "sim/simdefs" )
+local astar = include( "modules/astar" )
 local astar_handlers = include( "sim/astar_handlers" )
+local simdefs = include( "sim/simdefs" )
+
+-- ===================
+-- modules/astar.AStar
+-- ===================
+
+local function aStarTracePath( originalFunction, self, n, ... )
+	-- restore realCost if present
+	if n.realCost then
+		local p = n
+		while p do
+			p.mCost = p.realCost or p.mCost
+			p = p.parent
+		end
+	end
+
+	return originalFunction( self, n, ... )
+end
+
+-- ==========================
+-- sim/astar_handlers.handler
+-- ==========================
+
+local function getNode( originalFunction, self, cell, parentNode, ... )
+	local n = originalFunction( self, cell, parentNode, ... )
+	if n then
+		-- mCost: algorithmic cost of the move (includes avoidance penalties)
+		-- realCost: true MP cost of the move
+		n.realCost = 0
+	end
+	return n
+end
 
 local function handleNode( originalFunction, self, to_cell, from_node, goal_cell, ... )
+	if not self._unit:isPC() then
+		return originalFunction( self, to_cell, from_node, goal_cell, ... )
+	end
+
+	-- Hide max MP from the original function.
+	-- Perform the max MP check ourselves.
+	local maxMP = self._maxMP
+	self._maxMP = nil
+
 	local n = originalFunction( self, to_cell, from_node, goal_cell, ... )
 
-	if n and self._unit:isPC() then
+	if n then
 		local simquery = self._sim:getQuery()
-		local watchState = simquery.isCellWatched( self._sim, self._unit:getPlayerOwner(), to_cell.x, to_cell.y )
+
+		-- Update real MP cost
+		local dc = simquery.getMoveCost( from_node.location, to_cell )
+		n.realCost = from_node.realCost + dc
+
+		-- Check max MP against the real MP cost.
+		if maxMP and maxMP < n.realCost then
+			return
+		end
 
 		-- Penalize paths for moving through watched and noticed tiles.
 		-- Penalty is less than difference between paths with different real mp costs for reasonable path lengths.
+		local watchState = simquery.isCellWatched( self._sim, self._unit:getPlayerOwner(), to_cell.x, to_cell.y )
 		if watchState == simdefs.CELL_WATCHED then
 			n.mCost = n.mCost + 0.001
 			n.score = n.score + 0.001
@@ -20,11 +70,14 @@ local function handleNode( originalFunction, self, to_cell, from_node, goal_cell
 		end
 	end
 
+	self._maxMP = maxMP
 	return n
 end
 
 
 local patches = {
+    { package = astar.AStar, name = '_tracePath',   f = aStarTracePath },
+    { package = astar_handlers.handler, name = 'getNode',   f = getNode },
     { package = astar_handlers.handler, name = '_handleNode',   f = handleNode },
 }
 

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -12,7 +12,9 @@ local UI_TWEAKS_STRINGS =
 		DOORS_WHILE_DRAGGING = "LAY THAT BODY DOWN, BOY",
 		DOORS_WHILE_DRAGGING_TIP = "Allow door manipulation while dragging bodies",
 		COLORED_TRACKS = "YES, WE ARE ALL INDIVIDUALS!",
-		COLORED_TRACKS_TIP = "Guards get uniquely colored tracks and interest points"
+		COLORED_TRACKS_TIP = "Guards get uniquely colored tracks and interest points",
+		STEP_CAREFULLY = "STEP CAREFULLY, NOW",
+		STEP_CAREFULLY_TIP = "Agents prefer to avoid watched/noticed tiles, while still choosing a path with the shortest distance",
 	}
 }
 


### PR DESCRIPTION
Agent pathing will still return a shortest path, but now avoids watched/noticed tiles where possible (watched tiles avoided even more than noticed tiles). The vanilla pathing prefers a smooth path (minimizing `currentCumulativeApCost + geometricDistanceToGoal` at each point) that easily ends up getting unnecessarily seen.

Total AP cost for paths is a linear combination of `1`s and `sqrt(2)`s. In likely scenarios, this should take at least 100 more watched tiles on the shortest path before the modified node costs would cause it to violate "returns a shortest path from point A to point B"